### PR TITLE
added vendor path as env variable to support global composer installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following example uses the `darkly` theme. If you want to use another theme,
 ```
 {
     ...
-    "template": "vendor/tobiju/bookdown-bootswatch-templates/templates/darkly/main.php"
+    "template": "../vendor/tobiju/bookdown-bootswatch-templates/templates/darkly/main.php"
 }
 ```
 
@@ -51,13 +51,15 @@ Visit [bootswatch.com](https://bootswatch.com/) to see how the theme looks like.
 
 ## Generate Documentation
 
-> Change the path to your bookdown.json. The following commands uses the documentation in this repository for an example.
+> Change the path to your bookdown.json file. The following commands uses the documentation in this repository for an example.
 
-Documentation example is [in the doc tree](book/), and can be compiled using [bookdown](http://bookdown.io) and [Docker](https://www.docker.com/)
+Documentation example is [in the doc tree](book/), and can be compiled using [bookdown](http://bookdown.io) and [Docker](https://www.docker.com/).
+The following example uses the [Docker Bookdown](https://hub.docker.com/r/sandrokeil/bookdown/) and you can use it also
+out of the box for your project.
 
 ```console
-$ docker run -i -t=false --rm -v $(pwd):/app sandrokeil/bookdown book/bookdown.json
-$ docker run -i -t=false --rm -p 8080:8080 -v $(pwd):/app php:5.6-cli php -S 0.0.0.0:8080 -t /app/book/html
+$ docker run -it --rm -v $(pwd):/app sandrokeil/bookdown book/bookdown.json
+$ docker run -it --rm -p 8080:8080 -v $(pwd):/app php:5.6-cli php -S 0.0.0.0:8080 -t /app/book/html
 ```
 
 or make sure bookdown is installed globally via composer and `$HOME/.composer/vendor/bin` is on your `$PATH`.
@@ -72,5 +74,4 @@ Then browse to [http://localhost:8080/](http://localhost:8080/)
 ## Further Information
 
 * [bookdown](https://github.com/bookdown/Bookdown.Bookdown)
-
-
+* [Docker bookdown image with these templates](https://hub.docker.com/r/sandrokeil/bookdown/)

--- a/templates/cerulean/main.php
+++ b/templates/cerulean/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = "vendor/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/cerulean/main.php
+++ b/templates/cerulean/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor/') . "bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/cosmo/main.php
+++ b/templates/cosmo/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = "vendor/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/cosmo/main.php
+++ b/templates/cosmo/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor/') . "bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/cyborg/main.php
+++ b/templates/cyborg/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = "vendor/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/cyborg/main.php
+++ b/templates/cyborg/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor/') . "bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/darkly/main.php
+++ b/templates/darkly/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = "vendor/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/darkly/main.php
+++ b/templates/darkly/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor/') . "bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/flatly/main.php
+++ b/templates/flatly/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = "vendor/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/flatly/main.php
+++ b/templates/flatly/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor/') . "bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/journal/main.php
+++ b/templates/journal/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = "vendor/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/journal/main.php
+++ b/templates/journal/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor/') . "bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/lumen/main.php
+++ b/templates/lumen/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = "vendor/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/lumen/main.php
+++ b/templates/lumen/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor/') . "bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/paper/main.php
+++ b/templates/paper/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = "vendor/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/paper/main.php
+++ b/templates/paper/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor/') . "bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/readable/main.php
+++ b/templates/readable/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = "vendor/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/readable/main.php
+++ b/templates/readable/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor/') . "bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/sandstone/main.php
+++ b/templates/sandstone/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = "vendor/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/sandstone/main.php
+++ b/templates/sandstone/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor/') . "bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/simplex/main.php
+++ b/templates/simplex/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = "vendor/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/simplex/main.php
+++ b/templates/simplex/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor/') . "bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/slate/main.php
+++ b/templates/slate/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = "vendor/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/slate/main.php
+++ b/templates/slate/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor/') . "bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/spacelab/main.php
+++ b/templates/spacelab/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = "vendor/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/spacelab/main.php
+++ b/templates/spacelab/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor/') . "bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/superhero/main.php
+++ b/templates/superhero/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = "vendor/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/superhero/main.php
+++ b/templates/superhero/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor/') . "bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/united/main.php
+++ b/templates/united/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = "vendor/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/united/main.php
+++ b/templates/united/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor/') . "bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/yeti/main.php
+++ b/templates/yeti/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = "vendor/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;

--- a/templates/yeti/main.php
+++ b/templates/yeti/main.php
@@ -1,6 +1,6 @@
 <?php
 // default library templates
-$library = (getenv('VENDOR_PATH') ?: 'vendor') . "/bookdown/bookdown/templates";
+$library = (getenv('VENDOR_PATH') ?: 'vendor/') . "bookdown/bookdown/templates";
 
 // project-specific templates
 $template_path = __DIR__;


### PR DESCRIPTION
Now it's possible to configure the vendor path by setting the `VENDOR_PATH` as environment variable, so the templates can be installed with `composer global require tobiju/bookdown-bootswatch-templates`
