### PR TITLE
Allow accent and other multibytes character to be display correctly

### DIFF
--- a/templates/partial/sideNav.php
+++ b/templates/partial/sideNav.php
@@ -31,7 +31,7 @@ $startLevel = 0;
             $maxStingLength = 24;
             $title = $entry->getTitle();
             if (strlen($title) > $maxStingLength) {
-                $title = substr($title, 0, $maxStingLength) . '...';
+                $title = mb_substr($title, 0, $maxStingLength) . '...';
             }
             ?>
             <li>


### PR DESCRIPTION
I've recently try to genereate [kanboard](https://github.com/kanboard/website) french documentation, and discover that accent are not correctly displayed in the sidenav.

For example with https://github.com/kanboard/website/blob/master/data/documentation/fr_FR/screenshots.markdown  and title `Ajouter des captures d'écran`
![sidenav](https://cloud.githubusercontent.com/assets/364342/19468308/ed542fba-9515-11e6-9e7b-477dcbff820d.png)
